### PR TITLE
Hotfix for incorrect counter increment for R123Generator4x generators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Random123"
 uuid = "74087812-796a-5b5d-8853-05524746bad3"
 authors = ["Sunoru <s@sunoru.com>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/common.jl
+++ b/src/common.jl
@@ -65,9 +65,15 @@ end
 end
 @inline function inc_counter!(r::R123Generator4x{T}) where T
     r.ctr1 += one(T)
-    r.ctr1 == zero(T) && (r.ctr2 += one(T))
-    r.ctr2 == zero(T) && (r.ctr3 += one(T))
-    r.ctr3 == zero(T) && (r.ctr4 += one(T))
+    if r.ctr1 == zero(T)
+        r.ctr2 += one(T)
+        if r.ctr2 == zero(T)
+            r.ctr3 += one(T)
+            if r.ctr3 == zero(T)
+                r.ctr4 += one(T)
+            end
+        end
+    end
     r
 end
 


### PR DESCRIPTION
Random123 v1.4.0 now increments all counter fields (I think #5 can be closed now), but does so incorrectly for R123Generator4x generators: it increments `ctr3` in parallel with `ctr1`:

```julia
julia> using Random123

julia> r = Philox4x()
Philox4x{UInt64, 10}(0x85dc666f04ca7117, 0x91f93bdbc1b4ddfd, 0x9aeff0a67d75d113, 0x49c8fa9f501ad38b, 0x1ae41951b41e08b9, 0xa38977fb635aac5c, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0)

julia> (rng.ctr4, rng.ctr3, rng.ctr2, rng.ctr1)
(0x0000000000000000, 0x0000000000000004, 0x0000000000000000, 0x0000000000000005)

julia> Random123.inc_counter!(rng); (rng.ctr4, rng.ctr3, rng.ctr2, rng.ctr1)
(0x0000000000000000, 0x0000000000000005, 0x0000000000000000, 0x0000000000000006)
```

This break applications (like BAT.jl) that partition the counter space for reproducible parallel processing.

PR contains a fix and increases the package version as well.

@sunoru I'd be super grateful for a quick merge and a v1.4.1 bugfix release, since [BAT.jl](https://github.com/bat/BAT.jl) is currently broken due to this.