### PR TITLE
Add AArch64 macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,22 @@ jobs:
     strategy:
       matrix:
         julia-version: ["1.8", "1.10", nightly]
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        julia-arch: [x64, x86, aarch64]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         exclude:
-          - os: macOS-latest
+          - os: ubuntu-latest
+            julia-arch: aarch64
+          - os: windows-latest
+            julia-arch: aarch64
+          - os: macos-13
             julia-arch: x86
+          - os: macos-13
+            julia-arch: aarch64
+          - os: macos-latest
+            julia-arch: x86
+          - os: macos-latest
+            julia-arch: aarch64
+            julia-version: 1.8
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is the only publicly available Arm runner GitHub offers, so far, though with any luck the Linux Arm runners will be public later this year.  Technically CI was already testing on Apple Silicon, under Rosetta 2, since `macos-latest` was selected and now points to an M1 instance.  This finally admits it and sets things up so that the following combinations are all tested:

- i686 Ubuntu
- x86_64 Ubuntu
- i686 Windows
- x86_64 Windows
- x86_64 macOS 13 on an Intel CPU
- x86_64 macOS 14 on an M1 (via Rosetta 2)
- AArch64 macOS 14 on an M1 (natively), except Julia 1.8

Further addition of AArch64 Ubuntu awaits GitHub's publicization of those runners; maybe in the future we'll also get AArch64 Windows runners, but no such plans have been announced.  At least we can test on AArch64 at all now!